### PR TITLE
Refactor Hub threading & locking

### DIFF
--- a/services/domotics/bridge/sync_bridge_service.go
+++ b/services/domotics/bridge/sync_bridge_service.go
@@ -171,6 +171,7 @@ func (s *SyncBridgeService) StreamBridgeUpdates(req *StreamBridgeUpdatesRequest,
 	logger.Debug("bridge update stream initiated")
 
 	sink := s.updates.NewSink()
+	defer sink.Close()
 
 	// Send all of the devices to start.
 	for _, device := range s.devices {
@@ -214,9 +215,7 @@ func (s *SyncBridgeService) StreamBridgeUpdates(req *StreamBridgeUpdatesRequest,
 			panic("update cast incorrect")
 		}
 
-		logger.Debug("sending update",
-			zap.String("info", bridgeUpdate.String()),
-		)
+		logger.Debug("sending update")
 
 		if err := stream.Send(bridgeUpdate); err != nil {
 			return err

--- a/services/domotics/integrations/googlehome/cmd/googlebridged/proxy.go
+++ b/services/domotics/integrations/googlehome/cmd/googlebridged/proxy.go
@@ -79,8 +79,9 @@ func (p *Proxy) Run() error {
 
 func (p *Proxy) processHubUpdates(relayStream googlehome.GoogleHomeService_StateSyncClient) {
 	// Listen to updates from the bridge and forward the relevant commands (RequestSync, ReportState) to the relay
+	updateChan := p.h.Updates()
 	for {
-		update := <-p.h.Updates()
+		update := <-updateChan
 		// Google doesn't care about bridge changes.
 		if deviceUpdate := update.GetDeviceUpdate(); deviceUpdate != nil {
 			p.logger.Debug("received update from bridge")


### PR DESCRIPTION
* move to a dedicated channel + RWLock for bridge & device updates
  - this simplifies the logic for updating devices or bridges in a hub
* remove very verbose stream logging
* add deferred sink close calls
* avoid creating many channels for google relaying